### PR TITLE
fix: publish to GitHub Packages on release instead of Docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,16 @@ on:
     types: [published]
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: dmk1111/puppeteer
-          tag_with_ref: true
+      - name: Push to GitHub Packages
+          uses: docker/build-push-action@v1
+          with:
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITH_TOKEN }}
+            registry: docker.pkg.github.com
+            repository: dmk1111/puppeteer
+            tag_with_ref: true


### PR DESCRIPTION
Docker automatically publishes new container on merge into `master`